### PR TITLE
fixed syntax error in Com-Server-Intern-MIB

### DIFF
--- a/mibs/webgraph/Com-Server-Intern-MIB
+++ b/mibs/webgraph/Com-Server-Intern-MIB
@@ -263,7 +263,7 @@ wtCableType OBJECT-TYPE
     SYNTAX INTEGER {
         wtCoax(1),
         wtTwistedPair(2),
-        wtAui(3)
+        wtAui(3),
         wtTwistedPair10FD(4),
 		wtTwistedPair100HD(8),
         wtTwistedPair100FD(16)


### PR DESCRIPTION
Com-Server-Intern-MIB could not be parsed correctly because of syntax issues in SYNTAX