### PR TITLE
Remove old files as well as adding new ones.

### DIFF
--- a/.github/scripts/update.sh
+++ b/.github/scripts/update.sh
@@ -11,8 +11,8 @@ echo "Extracting Observium archive..."
 wget https://www.observium.org/observium-community-latest.tar.gz -O - -q \
     | tar -xzf - -C .new
 
-echo "Copying files..."
-cp -r .new/observium/* .
+echo "Updating files..."
+rsync -ra --exclude logs --exclude rrd --exclude .new --exclude .git* --delete-after .new/observium/ .
 
 echo "Deleting archive..."
 rm -rf .new


### PR DESCRIPTION
During updates, observium sometimes remove files.

The official upgrade instructions cater for this by having you create an entirely fresh install each time, but the upgrade process in this repo doesn't account for that.

This modified `update.sh` will deal with that by using rsync to handle copying from the new archive