### PR TITLE
SnmpEngineID Duplicate

### DIFF
--- a/includes/entities/device.inc.php
+++ b/includes/entities/device.inc.php
@@ -806,7 +806,7 @@ function check_device_duplicated($device)
                     if ($compare) {
                         // This devices really same, with same sysName, snmpEngineID and entPhysicalSerialNum
                         print_error("Already got device with SNMP-read sysName ($sysName), 'snmpEngineID' = $snmpEngineID and 'entPhysicalSerialNum' = $serial (" . $test['hostname'] . ").");
-                        return TRUE;
+                        return false;
                     }
                 } else {
                     // For not FQDN sysname check all (other) possible system Oids:


### PR DESCRIPTION
 
- virtual machine having the same snmp EngineID will be monitored which will reduce time to change the snmpEngineID in each host in case of large environment.