### PR TITLE
Use absolute paths so html/pages/device/logs/ isn't ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-logs/
-rrd/
-config.php
+/logs/
+/rrd/
+/config.php


### PR DESCRIPTION
The .gitignore file uses relative paths, so the html/pages/device/logs/ subfolder is missing from this mirror. This means that the per-device eventlog page at https://observium.domain/device/device=1/tab=logs/section=eventlog/ is empty.

Changing this to absolute paths means that /logs/ will still be ignored, but /html/pages/device/logs/ will not.